### PR TITLE
Add zero case for word count

### DIFF
--- a/src/components/PageContent/index.tsx
+++ b/src/components/PageContent/index.tsx
@@ -26,7 +26,7 @@ class PageContent extends React.Component<IPageContent, {}> {
         <h2>{author}</h2>
         <h3>{datePublished}</h3>
         <h3>{url}</h3>
-        <h3>{wordCount}</h3>
+        <h3>{wordCount} {wordCount == 1 ? "word" : "words"}</h3>
         {content && <Content dangerouslySetInnerHTML={{ __html: content }} />}
       </Wrapper>
     );

--- a/src/components/PageContent/index.tsx
+++ b/src/components/PageContent/index.tsx
@@ -26,7 +26,7 @@ class PageContent extends React.Component<IPageContent, {}> {
         <h2>{author}</h2>
         <h3>{datePublished}</h3>
         <h3>{url}</h3>
-        <h3>{wordCount} {wordCount == 1 ? "word" : "words"}</h3>
+        <h3>{wordCount} {wordCount > 1 ? "words" : wordCount == 1 ? "word" : null}</h3>
         {content && <Content dangerouslySetInnerHTML={{ __html: content }} />}
       </Wrapper>
     );


### PR DESCRIPTION
When the word count is zero (aka doesn't exist), we don't want any text to appear. Add a case for this.